### PR TITLE
Fix build workflow Yarn install lockfile error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Lint the extension
         run: |
           set -eux
-          jlpm
+          jlpm install --immutable
           jlpm run lint:check
 
       - name: Build the extension


### PR DESCRIPTION
## Summary
- update the build workflow to run `jlpm install --immutable` before linting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a4fdac888325856cadf1c92f9537